### PR TITLE
fix: use proper path with go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Gobalt provides a way to communicate with [cobalt.tools](https://cobalt.tools) using Go. To use it in your projects, simply run this command:
 ```sh
-go get https://github.com/lostdusty/gobalt
+go get github.com/lostdusty/gobalt
 ```
 
 ## Usage


### PR DESCRIPTION
Hi! cool project thanks for providing us with this code. 

I was trying to `go get https://github.com/lostdusty/gobalt`
but I got this error:
<img width="581" alt="Screenshot 2024-07-04 at 17 48 45" src="https://github.com/lostdusty/gobalt/assets/41418470/9ad0a95d-e136-48de-aadc-71201855368d">

Apparently golang can just skip the url scheme and `go get github.com/lostdusty/gobalt` works just fine so please consider changing it! 

This PR fixes that.